### PR TITLE
feat: play sound on sink volume change

### DIFF
--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -6,7 +6,10 @@ use cosmic::{
     iced_sctk::settings::InitialSurface,
     iced_style::application,
 };
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
 
 use crate::{
     components::{osd_indicator, polkit_dialog},
@@ -28,7 +31,6 @@ enum Surface {
     PolkitDialog(polkit_dialog::State),
 }
 
-#[derive(Default)]
 struct App {
     connection: Option<zbus::Connection>,
     system_connection: Option<zbus::Connection>,
@@ -36,11 +38,31 @@ struct App {
     indicator: Option<(SurfaceId, osd_indicator::State)>,
     display_brightness: Option<i32>,
     keyboard_brightness: Option<i32>,
-    sink_volume: Option<u32>,
+    sink_last_playback: Instant,
     sink_mute: Option<bool>,
-    source_volume: Option<u32>,
+    sink_volume: Option<u32>,
     source_mute: Option<bool>,
+    source_volume: Option<u32>,
     airplane_mode: Option<bool>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            connection: None,
+            system_connection: None,
+            surfaces: HashMap::new(),
+            indicator: None,
+            display_brightness: None,
+            keyboard_brightness: None,
+            sink_last_playback: Instant::now(),
+            sink_mute: None,
+            sink_volume: None,
+            source_mute: None,
+            source_volume: None,
+            airplane_mode: None,
+        }
+    }
 }
 
 impl App {
@@ -181,6 +203,13 @@ impl Application for App {
                         }
                     }
                     pulse::Event::SinkVolume(volume) => {
+                        let now = Instant::now();
+                        if now.duration_since(self.sink_last_playback) > Duration::from_millis(125)
+                        {
+                            self.sink_last_playback = now;
+                            pipewire::play_audio_volume_change();
+                        }
+
                         if self.sink_volume.is_none() {
                             self.sink_volume = Some(volume);
                         } else if self.sink_volume != Some(volume) {
@@ -274,4 +303,28 @@ pub fn main() -> iced::Result {
         initial_surface: InitialSurface::None,
         ..Default::default()
     })
+}
+
+mod pipewire {
+    // Copyright 2023 System76 <info@system76.com>
+    // SPDX-License-Identifier: MPL-2.0
+
+    use std::path::Path;
+    use std::process::Stdio;
+
+    /// Plays an audio file.
+    pub fn play(path: &Path) {
+        let _result = tokio::process::Command::new("pw-play")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .arg(path)
+            .spawn();
+    }
+
+    pub fn play_audio_volume_change() {
+        play(Path::new(
+            "/usr/share/sounds/freedesktop/stereo/audio-volume-change.oga",
+        ));
+    }
 }


### PR DESCRIPTION
Uses `pw-play` to play the `freedesktop/stereo/audio-volume-change` sound when the sink volume changes.
This is the same as what's being used by the audio applet, which can be removed once this is merged.