### PR TITLE
Change OSD close timer to be 3 seconds

### DIFF
--- a/src/components/osd_indicator.rs
+++ b/src/components/osd_indicator.rs
@@ -95,7 +95,7 @@ pub struct State {
 
 fn close_timer() -> (Command<Msg>, AbortHandle) {
     let (future, timer_abort) = abortable(async {
-        let duration = Duration::from_secs(5);
+        let duration = Duration::from_secs(3);
         tokio::time::sleep(duration).await;
     });
     let command = Command::perform(future, |res| {


### PR DESCRIPTION
Changes the timer for closing the OSD to be 3 seconds as the previous value of 3 seconds was determined to be too long