### PR TITLE
support CARGO_TARGET_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ includedir = $(prefix)/include
 datarootdir = $(prefix)/share
 datadir = $(datarootdir)
 
+CARGO_TARGET_DIR ?= target
 TARGET = debug
 DEBUG ?= 0
 ifeq ($(DEBUG),0)
@@ -32,7 +33,7 @@ $(BIN): Cargo.toml Cargo.lock src/main.rs vendor-check
 	POLKIT_AGENT_HELPER_1=$(polkit-agent-helper-1) cargo build $(ARGS) --bin ${BIN}
 
 install:
-	install -Dm0755 target/$(TARGET)/$(BIN) $(DESTDIR)$(bindir)/$(BIN)
+	install -Dm0755 $(CARGO_TARGET_DIR)/$(TARGET)/$(BIN) $(DESTDIR)$(bindir)/$(BIN)
 
 ## Cargo Vendoring
 


### PR DESCRIPTION
Previously failed to install/run from source when CARGO_TARGET_DIR is set, because the Makefile assumed the target dir was './target'.

I noticed there is another PR that replaces the Makefile with a justfile, but that one does not support CARGO_TARGET_DIR yet. When that is fixed and the PR gets merged, this PR would of course be obsolete and could be closed.