### PR TITLE
Update osd view layout

### DIFF
--- a/src/components/osd_indicator.rs
+++ b/src/components/osd_indicator.rs
@@ -155,25 +155,25 @@ impl State {
         let osd_contents = if let Some(value) = self.params.value() {
             radius = cosmic::theme::active().cosmic().radius_l();
             const OSD_WIDTH: f32 = 392.0;
-            const OSD_HEIGHT: f32 = 64.0;
-            const FLANK_WIDTH: f32 = 40.0;
+            const OSD_HEIGHT: f32 = 52.0;
+            const FLANK_WIDTH: f32 = 36.0;
             const SPACING: f32 = 12.0;
-            const BAR_WIDTH: f32 = OSD_WIDTH - 2.0 * FLANK_WIDTH - 6.0 * SPACING;
+            const BAR_WIDTH: f32 = OSD_WIDTH - 2.0 * FLANK_WIDTH - 1.15 * OSD_HEIGHT;
             cosmic::widget::container(
                 widget::row![
                     cosmic::widget::container(icon.size(20))
                         .width(FLANK_WIDTH)
                         .align_x(iced::alignment::Horizontal::Center),
+                    cosmic::widget::horizontal_space(SPACING),
                     cosmic::widget::progress_bar(0. ..=100., value as f32)
-                        .height(8)
+                        .height(4)
                         .width(BAR_WIDTH),
                     cosmic::widget::text(format!("{}%", value))
                         .size(16)
-                        .width(FLANK_WIDTH)
+                        .width(FLANK_WIDTH + SPACING)
                         .horizontal_alignment(iced::alignment::Horizontal::Right),
                 ]
-                .align_items(iced::Alignment::Center)
-                .spacing(SPACING),
+                .align_items(iced::Alignment::Center),
             )
             .width(OSD_WIDTH)
             .height(OSD_HEIGHT)

--- a/src/components/osd_indicator.rs
+++ b/src/components/osd_indicator.rs
@@ -147,18 +147,29 @@ impl State {
     }
 
     pub fn view(&self) -> Element<'_, Msg> {
-        let icon = cosmic::widget::icon::from_name(self.params.icon_name());
-        // TODO if value is None, large icon
-        // TODO: show as percent
+        let icon = cosmic::widget::icon::from_name(self.params.icon_name()).size(24);
+
         let row = if let Some(value) = self.params.value() {
-            let slider = cosmic::widget::slider(0..=100, value, |_| Msg::Ignore)
-                .width(iced::Length::Fixed(256.0));
-            widget::row![icon, iced::widget::text(format!("{}", value)), slider].spacing(4)
+            widget::row![
+                cosmic::widget::Container::new(icon)
+                    .width(iced::Length::FillPortion(1))
+                    .align_x(iced::alignment::Horizontal::Center),
+                cosmic::widget::progress_bar(0. ..=100., value as f32)
+                    .height(8)
+                    .width(iced::Length::FillPortion(5)),
+                iced::widget::text(format!("{}%", value))
+                    .size(16)
+                    .width(iced::Length::FillPortion(1))
+                    .horizontal_alignment(iced::alignment::Horizontal::Right)
+            ]
+            .spacing(8)
+            .align_items(iced::Alignment::Center)
+            .width(340)
         } else {
-            widget::row![icon]
+            widget::row![icon.size(48)]
         };
         widget::container::Container::new(row)
-            .padding(12)
+            .padding(16)
             .width(iced::Length::Shrink)
             .height(iced::Length::Shrink)
             .style(cosmic::theme::Container::custom(|theme| {
@@ -166,9 +177,9 @@ impl State {
                     text_color: Some(theme.cosmic().on_bg_color().into()),
                     background: Some(iced::Color::from(theme.cosmic().background.base).into()),
                     border: Border {
-                        radius: (12.0).into(),
-                        width: 0.0,
-                        color: iced::Color::TRANSPARENT,
+                        radius: theme.cosmic().radius_m().into(),
+                        width: 1.0,
+                        color: theme.cosmic().bg_divider().into(),
                     },
                     shadow: Default::default(),
                     icon_color: Some(theme.cosmic().on_bg_color().into()),


### PR DESCRIPTION
Hey! This is my first PR for Cosmic, so some things may not be standard styling, but I did my best.

I have updated the osd to have:
- Layout similar to audio applet, with each element in row having fixed width
- Use progress bar instead of slider, since the osd is not interactive
- Dynamic border radius dependent on style
- Border to increase contrast against dark background apps
- Larger icon for osd without a value, such as flight mode

https://github.com/user-attachments/assets/0ea46aa2-3389-4ff6-9d35-f2cd0bd04b3f

In the video the osd is higher up, but that is just for the illustration.

Also, when I run it locally, it does not seem to pick up on my display brightness changing, but that could just be an issue on my end.

