### PR TITLE
fix: display osd on keyboard event

### DIFF
--- a/src/subscriptions/keyboard.rs
+++ b/src/subscriptions/keyboard.rs
@@ -1,0 +1,33 @@
+use cosmic::{
+    iced::{self, event::listen_with, keyboard::Key},
+    iced_core::keyboard,
+};
+
+#[derive(Clone, Debug)]
+pub enum Msg {
+    BrightnessDown,
+    BrightnessUp,
+    AudioVolumeDown,
+    AudioVolumeUp,
+    AudioVolumeMute,
+}
+
+pub fn subscription() -> iced::Subscription<Msg> {
+    listen_with(|event, status| match status {
+        iced::event::Status::Ignored => match event {
+            iced::Event::Keyboard(keyboard::Event::KeyPressed {
+                key: Key::Named(named),
+                ..
+            }) => match named {
+                keyboard::key::Named::BrightnessDown => Some(Msg::BrightnessDown),
+                keyboard::key::Named::BrightnessUp => Some(Msg::BrightnessUp),
+                keyboard::key::Named::AudioVolumeDown => Some(Msg::AudioVolumeDown),
+                keyboard::key::Named::AudioVolumeUp => Some(Msg::AudioVolumeUp),
+                keyboard::key::Named::AudioVolumeMute => Some(Msg::AudioVolumeMute),
+                _ => None,
+            },
+            _ => None,
+        },
+        iced::event::Status::Captured => None,
+    })
+}

--- a/src/subscriptions/mod.rs
+++ b/src/subscriptions/mod.rs
@@ -1,3 +1,4 @@
 pub mod dbus;
+pub mod keyboard;
 pub mod polkit_agent;
 pub mod polkit_agent_helper;


### PR DESCRIPTION
fix #22 

Draft because it doesn't work on my PC. My guess is that `AudioVolumeDown` and Up are not recognized by Iced.

Also, not sure of the difference between Sink and Source so i don't know what i'm i doing