### PR TITLE
Add missing suspend translation for en

### DIFF
--- a/i18n/en/cosmic_osd.ftl
+++ b/i18n/en/cosmic_osd.ftl
@@ -3,6 +3,7 @@ authentication-required = Authentication Required
 cancel = Cancel
 authenticate = Authenticate
 log-out = Log Out
+suspend = Suspend
 restart = Restart
 enter-bios = Enter BIOS
 shutdown = Shutdown


### PR DESCRIPTION
Noticed while comparing another translation against the en, that the english i18n file was missing the translation for suspend.... ? I don't use english for the UI, but I assume it is desirable to have it?