### PR TITLE
feat: hotkey-only brightness OSD + battery AC plug/unplug indicator

### DIFF
--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -260,6 +260,8 @@ pub enum Msg {
     PolkitAgent(polkit_agent::Event),
     PolkitDialog((SurfaceId, polkit_dialog::Msg)),
     SettingsDaemon(settings_daemon::Event),
+    HotkeyBrightness(i32),
+    BatteryStatus(u32, bool, bool), // percent, on_battery, charging
     Pulse(pulse::Event),
     OsdIndicator(osd_indicator::Msg),
     AirplaneMode(bool),
@@ -299,6 +301,8 @@ struct App {
     source_mute: Option<bool>,
     source_volume: Option<u32>,
     airplane_mode: Option<bool>,
+    /// Tracks on_battery to detect AC plug/unplug and show a battery OSD.
+    on_battery: Option<bool>,
     overlap: HashMap<String, Rectangle>,
     size: Option<Size>,
     action_to_confirm: Option<(SurfaceId, OsdTask, u8)>,
@@ -443,6 +447,7 @@ impl cosmic::Application for App {
                 source_mute: None,
                 source_volume: None,
                 airplane_mode: None,
+                on_battery: None,
                 overlap: HashMap::new(),
                 size: None,
                 action_to_confirm: None,
@@ -598,27 +603,21 @@ impl cosmic::Application for App {
                 Task::none()
             }
             Msg::SettingsDaemon(settings_daemon::Event::DisplayBrightness(brightness)) => {
-                if self.display_brightness.is_none() {
-                    self.display_brightness = Some(brightness);
-                    Task::none()
-                } else if self.display_brightness != Some(brightness) {
-                    self.display_brightness = Some(brightness);
-                    if let Some(max) = self.max_display_brightness {
-                        if max <= 20 {
-                            // Coarse displays: rung_ratio=(raw+1)/20
-                            let rung_ratio = ((brightness + 1) as f64) / 20.0;
-                            self.create_indicator(osd_indicator::Params::DisplayBrightness(
-                                rung_ratio,
-                            ))
-                        } else {
-                            // Fine displays: exact integer percent from raw/max
-                            let ratio = (brightness as f64) / (max as f64);
-                            self.create_indicator(osd_indicator::Params::DisplayBrightnessExact(
-                                ratio,
-                            ))
-                        }
+                // Silently track brightness state but never show OSD for property
+                // changes. OSD is shown only on HotkeyBrightness events fired
+                // by cosmic-settings-daemon when the brightness hotkey is used.
+                self.display_brightness = Some(brightness);
+                Task::none()
+            }
+            Msg::HotkeyBrightness(brightness) => {
+                self.display_brightness = Some(brightness);
+                if let Some(max) = self.max_display_brightness {
+                    if max <= 20 {
+                        let rung_ratio = ((brightness + 1) as f64) / 20.0;
+                        self.create_indicator(osd_indicator::Params::DisplayBrightness(rung_ratio))
                     } else {
-                        Task::none()
+                        let ratio = (brightness as f64) / (max as f64);
+                        self.create_indicator(osd_indicator::Params::DisplayBrightnessExact(ratio))
                     }
                 } else {
                     Task::none()
@@ -689,6 +688,21 @@ impl cosmic::Application for App {
                     pulse::Event::Balance(_) | pulse::Event::Channels(_) => {}
                 }
                 Task::none()
+            }
+            Msg::BatteryStatus(pct, on_battery, charging) => {
+                // Only show OSD on actual AC plug/unplug transition (not on
+                // initial state detection or while-running percent updates).
+                if self.on_battery.is_none() {
+                    self.on_battery = Some(on_battery);
+                    Task::none()
+                } else if self.on_battery != Some(on_battery) {
+                    self.on_battery = Some(on_battery);
+                    self.create_indicator(osd_indicator::Params::BatteryStatus(
+                        pct, on_battery, charging,
+                    ))
+                } else {
+                    Task::none()
+                }
             }
             Msg::AirplaneMode(state) => {
                 if self.airplane_mode.is_none() {
@@ -1076,6 +1090,15 @@ impl cosmic::Application for App {
         if let Some(connection) = self.connection.clone() {
             subscriptions.push(settings_daemon::subscription(connection).map(Msg::SettingsDaemon));
         }
+
+        // Hotkey-only brightness signal — shows OSD only when brightness hotkey
+        // is pressed, not on other brightness changes (slider, programmatic).
+        subscriptions.push(hotkey_brightness_subscription().map(Msg::HotkeyBrightness));
+
+        // UPower AC plug/unplug notifier → battery status OSD
+        subscriptions.push(battery_status_subscription().map(|(pct, on_bat, chg)| {
+            Msg::BatteryStatus(pct, on_bat, chg)
+        }));
 
         subscriptions.push(pulse::subscription().map(Msg::Pulse));
 
@@ -1561,4 +1584,119 @@ fn min_width_and_height(
 
 fn text_icon(name: &str, size: u16) -> widget::Icon {
     icon::from_name(name).size(size).symbolic(true).icon()
+}
+
+/// Listens to the `DisplayBrightnessHotkey` signal from cosmic-settings-daemon.
+/// This signal is fired only when the brightness hotkey methods are called,
+/// so the OSD shows only for hotkey presses (not slider drags or programmatic
+/// brightness changes like the dim-idle feature).
+fn hotkey_brightness_subscription() -> cosmic::iced::Subscription<i32> {
+    use cosmic::iced::futures::{SinkExt, channel::mpsc, stream::StreamExt};
+    use std::hash::Hash;
+    #[derive(Clone)]
+    struct Id;
+    impl Hash for Id {
+        fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
+    }
+    cosmic::iced::Subscription::run_with(Id, |_| {
+        let (tx, rx) = mpsc::channel::<i32>(4);
+        tokio::spawn(async move {
+            let mut tx = tx;
+            loop {
+                if let Err(e) = listen_hotkey_signal(&mut tx).await {
+                    log::warn!("hotkey brightness signal listener error: {e}");
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                }
+            }
+        });
+        rx.boxed()
+    })
+}
+
+async fn listen_hotkey_signal(
+    output: &mut cosmic::iced::futures::channel::mpsc::Sender<i32>,
+) -> zbus::Result<()> {
+    use cosmic::iced::futures::{SinkExt, StreamExt};
+    let conn = zbus::Connection::session().await?;
+    let proxy = zbus::Proxy::new(
+        &conn,
+        "com.system76.CosmicSettingsDaemon",
+        "/com/system76/CosmicSettingsDaemon",
+        "com.system76.CosmicSettingsDaemon",
+    )
+    .await?;
+    let mut stream = proxy.receive_signal("DisplayBrightnessHotkey").await?;
+    while let Some(msg) = stream.next().await {
+        if let Ok(value) = msg.body().deserialize::<i32>() {
+            let _ = output.send(value).await;
+        }
+    }
+    Ok(())
+}
+
+/// Listens for UPower `OnBattery` property changes. Emits (percent, on_battery, charging)
+/// so the OSD can pop up a status modal when the AC adapter is plugged/unplugged.
+fn battery_status_subscription() -> cosmic::iced::Subscription<(u32, bool, bool)> {
+    use cosmic::iced::futures::{SinkExt, channel::mpsc, stream::StreamExt};
+    use std::hash::Hash;
+    #[derive(Clone)]
+    struct Id;
+    impl Hash for Id {
+        fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
+    }
+    cosmic::iced::Subscription::run_with(Id, |_| {
+        let (tx, rx) = mpsc::channel::<(u32, bool, bool)>(4);
+        tokio::spawn(async move {
+            let mut tx = tx;
+            loop {
+                if let Err(e) = listen_upower_ac(&mut tx).await {
+                    log::warn!("upower ac listener error: {e}");
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                }
+            }
+        });
+        rx.boxed()
+    })
+}
+
+async fn listen_upower_ac(
+    output: &mut cosmic::iced::futures::channel::mpsc::Sender<(u32, bool, bool)>,
+) -> zbus::Result<()> {
+    use cosmic::iced::futures::{SinkExt, StreamExt};
+    let conn = zbus::Connection::system().await?;
+    let proxy = zbus::Proxy::new(
+        &conn,
+        "org.freedesktop.UPower",
+        "/org/freedesktop/UPower",
+        "org.freedesktop.UPower",
+    )
+    .await?;
+    // Emit initial state so the app tracks it
+    let on_battery: bool = proxy.get_property("OnBattery").await.unwrap_or(false);
+    let (pct, charging) = get_display_device_state(&conn).await.unwrap_or((0, false));
+    let _ = output.send((pct, on_battery, charging)).await;
+
+    let mut changes = proxy.receive_property_changed::<bool>("OnBattery").await;
+    while let Some(change) = changes.next().await {
+        let on_battery = change.get().await.unwrap_or(false);
+        let (pct, charging) = get_display_device_state(&conn).await.unwrap_or((0, false));
+        let _ = output.send((pct, on_battery, charging)).await;
+    }
+    Ok(())
+}
+
+async fn get_display_device_state(
+    conn: &zbus::Connection,
+) -> zbus::Result<(u32, bool)> {
+    let dev_proxy = zbus::Proxy::new(
+        conn,
+        "org.freedesktop.UPower",
+        "/org/freedesktop/UPower/devices/DisplayDevice",
+        "org.freedesktop.UPower.Device",
+    )
+    .await?;
+    let pct: f64 = dev_proxy.get_property("Percentage").await.unwrap_or(0.0);
+    let state: u32 = dev_proxy.get_property("State").await.unwrap_or(0);
+    // State 1 = Charging
+    Ok((pct.round() as u32, state == 1))
 }

--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -260,6 +260,8 @@ pub enum Msg {
     PolkitAgent(polkit_agent::Event),
     PolkitDialog((SurfaceId, polkit_dialog::Msg)),
     SettingsDaemon(settings_daemon::Event),
+    HotkeyBrightness(i32, i32),
+    BatteryStatus(u32, bool, bool), // percent, on_battery, charging
     Pulse(pulse::Event),
     OsdIndicator(osd_indicator::Msg),
     AirplaneMode(bool),
@@ -296,9 +298,14 @@ struct App {
     sink_last_playback: Instant,
     sink_mute: Option<bool>,
     sink_volume: Option<u32>,
+    /// Name of the current default audio sink (e.g. `bluez_output.*` /
+    /// `alsa_output.*-headphones`); used to pick a device-aware volume OSD icon.
+    default_sink_name: Option<String>,
     source_mute: Option<bool>,
     source_volume: Option<u32>,
     airplane_mode: Option<bool>,
+    /// Tracks on_battery to detect AC plug/unplug and show a battery OSD.
+    on_battery: Option<bool>,
     overlap: HashMap<String, Rectangle>,
     size: Option<Size>,
     action_to_confirm: Option<(SurfaceId, OsdTask, u8)>,
@@ -446,9 +453,11 @@ impl cosmic::Application for App {
                 sink_last_playback: Instant::now(),
                 sink_mute: None,
                 sink_volume: None,
+                default_sink_name: None,
                 source_mute: None,
                 source_volume: None,
                 airplane_mode: None,
+                on_battery: None,
                 overlap: HashMap::new(),
                 size: None,
                 action_to_confirm: None,
@@ -604,30 +613,22 @@ impl cosmic::Application for App {
                 Task::none()
             }
             Msg::SettingsDaemon(settings_daemon::Event::DisplayBrightness(brightness)) => {
-                if self.display_brightness.is_none() {
-                    self.display_brightness = Some(brightness);
-                    Task::none()
-                } else if self.display_brightness != Some(brightness) {
-                    self.display_brightness = Some(brightness);
-                    if let Some(max) = self.max_display_brightness {
-                        if max <= 20 {
-                            // Coarse displays: rung_ratio=(raw+1)/20
-                            let rung_ratio = ((brightness + 1) as f64) / 20.0;
-                            self.create_indicator(osd_indicator::Params::DisplayBrightness(
-                                rung_ratio,
-                            ))
-                        } else {
-                            // Fine displays: exact integer percent from raw/max
-                            let ratio = (brightness as f64) / (max as f64);
-                            self.create_indicator(osd_indicator::Params::DisplayBrightnessExact(
-                                ratio,
-                            ))
-                        }
-                    } else {
-                        Task::none()
-                    }
+                // Silently track brightness state but never show OSD for property
+                // changes. OSD is shown only on HotkeyBrightness events fired
+                // by cosmic-settings-daemon when the brightness hotkey is used.
+                self.display_brightness = Some(brightness);
+                Task::none()
+            }
+            Msg::HotkeyBrightness(brightness, max) => {
+                // Cache the values so other code paths see fresh state.
+                self.display_brightness = Some(brightness);
+                self.max_display_brightness = Some(max);
+                if max <= 20 {
+                    let rung_ratio = ((brightness + 1) as f64) / 20.0;
+                    self.create_indicator(osd_indicator::Params::DisplayBrightness(rung_ratio))
                 } else {
-                    Task::none()
+                    let ratio = (brightness as f64) / (max as f64);
+                    self.create_indicator(osd_indicator::Params::DisplayBrightnessExact(ratio))
                 }
             }
             Msg::Pulse(evt) => {
@@ -638,9 +639,11 @@ impl cosmic::Application for App {
                         } else if self.sink_mute != Some(mute) {
                             self.sink_mute = Some(mute);
                             if let Some(sink_volume) = self.sink_volume {
+                                let kind = sink_kind_from_name(self.default_sink_name.as_deref());
                                 return self.create_indicator(osd_indicator::Params::SinkVolume(
                                     sink_volume,
                                     mute,
+                                    kind,
                                 ));
                             }
                         }
@@ -658,8 +661,9 @@ impl cosmic::Application for App {
                         } else if self.sink_volume != Some(volume) {
                             self.sink_volume = Some(volume);
                             if let Some(mute) = self.sink_mute {
+                                let kind = sink_kind_from_name(self.default_sink_name.as_deref());
                                 return self.create_indicator(osd_indicator::Params::SinkVolume(
-                                    volume, mute,
+                                    volume, mute, kind,
                                 ));
                             }
                         }
@@ -690,11 +694,28 @@ impl cosmic::Application for App {
                         }
                     }
                     pulse::Event::CardInfo(_) => {}
-                    pulse::Event::DefaultSink(_) => {}
+                    pulse::Event::DefaultSink(name) => {
+                        self.default_sink_name = Some(name);
+                    }
                     pulse::Event::DefaultSource(_) => {}
                     pulse::Event::Balance(_) | pulse::Event::Channels(_) => {}
                 }
                 Task::none()
+            }
+            Msg::BatteryStatus(pct, on_battery, charging) => {
+                // Only show OSD on actual AC plug/unplug transition (not on
+                // initial state detection or while-running percent updates).
+                if self.on_battery.is_none() {
+                    self.on_battery = Some(on_battery);
+                    Task::none()
+                } else if self.on_battery != Some(on_battery) {
+                    self.on_battery = Some(on_battery);
+                    self.create_indicator(osd_indicator::Params::BatteryStatus(
+                        pct, on_battery, charging,
+                    ))
+                } else {
+                    Task::none()
+                }
             }
             Msg::AirplaneMode(state) => {
                 if self.airplane_mode.is_none() {
@@ -1091,6 +1112,16 @@ impl cosmic::Application for App {
         if let Some(connection) = self.connection.clone() {
             subscriptions.push(settings_daemon::subscription(connection).map(Msg::SettingsDaemon));
         }
+
+        // Hotkey-only brightness signal — shows OSD only when brightness hotkey
+        // is pressed, not on other brightness changes (slider, programmatic).
+        subscriptions
+            .push(hotkey_brightness_subscription().map(|(b, m)| Msg::HotkeyBrightness(b, m)));
+
+        // UPower AC plug/unplug notifier → battery status OSD
+        subscriptions.push(battery_status_subscription().map(|(pct, on_bat, chg)| {
+            Msg::BatteryStatus(pct, on_bat, chg)
+        }));
 
         subscriptions.push(pulse::subscription().map(Msg::Pulse));
 
@@ -1576,4 +1607,150 @@ fn min_width_and_height(
 
 fn text_icon(name: &str, size: u16) -> widget::Icon {
     icon::from_name(name).size(size).symbolic(true).icon()
+}
+
+/// Coarse-classify the default audio sink for the volume OSD icon.
+///
+/// The pulse subscription only gives us the sink's node name (e.g.
+/// `bluez_output.58_18_62_27_28_EA.1`, `alsa_output.pci-...HiFi__Headphones__sink`),
+/// not its full property set — but the name is enough to distinguish the
+/// common cases. Anything we can't recognise falls back to `Speaker`,
+/// which preserves the upstream icon family.
+fn sink_kind_from_name(name: Option<&str>) -> osd_indicator::SinkKind {
+    let n = match name {
+        Some(s) => s,
+        None => return osd_indicator::SinkKind::Speaker,
+    };
+    if n.starts_with("bluez_output.") || n.starts_with("bluez_sink.") {
+        osd_indicator::SinkKind::Bluetooth
+    } else if n.contains("headphone") || n.contains("Headphone") {
+        // Wired headphones: the alsa node name carries the route, e.g.
+        // `alsa_output.pci-....HiFi__Headphones__sink`.
+        osd_indicator::SinkKind::Headphones
+    } else {
+        osd_indicator::SinkKind::Speaker
+    }
+}
+
+/// Listens to the `DisplayBrightnessHotkey` signal from cosmic-settings-daemon.
+/// This signal is fired only when the brightness hotkey methods are called,
+/// so the OSD shows only for hotkey presses (not slider drags or programmatic
+/// brightness changes like the dim-idle feature).
+fn hotkey_brightness_subscription() -> cosmic::iced::Subscription<(i32, i32)> {
+    use cosmic::iced::futures::{SinkExt, channel::mpsc, stream::StreamExt};
+    use std::hash::Hash;
+    #[derive(Clone)]
+    struct Id;
+    impl Hash for Id {
+        fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
+    }
+    cosmic::iced::Subscription::run_with(Id, |_| {
+        let (tx, rx) = mpsc::channel::<(i32, i32)>(4);
+        tokio::spawn(async move {
+            let mut tx = tx;
+            loop {
+                if let Err(e) = listen_hotkey_signal(&mut tx).await {
+                    log::warn!("hotkey brightness signal listener error: {e}");
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                }
+            }
+        });
+        rx.boxed()
+    })
+}
+
+async fn listen_hotkey_signal(
+    output: &mut cosmic::iced::futures::channel::mpsc::Sender<(i32, i32)>,
+) -> zbus::Result<()> {
+    use cosmic::iced::futures::{SinkExt, StreamExt};
+    let conn = zbus::Connection::session().await?;
+    let proxy = zbus::Proxy::new(
+        &conn,
+        "com.system76.CosmicSettingsDaemon",
+        "/com/system76/CosmicSettingsDaemon",
+        "com.system76.CosmicSettingsDaemon",
+    )
+    .await?;
+    // Pair the new-brightness value from the signal with `MaxDisplayBrightness`
+    // so the OSD doesn't depend on a separately-arriving SettingsDaemon
+    // subscription having populated `max` first. Without this, hotkey OSD silently
+    // no-ops if the signal arrives before the property subscription does.
+    let max: i32 = proxy
+        .get_property::<i32>("MaxDisplayBrightness")
+        .await
+        .unwrap_or(20);
+    let mut stream = proxy.receive_signal("DisplayBrightnessHotkey").await?;
+    while let Some(msg) = stream.next().await {
+        if let Ok(value) = msg.body().deserialize::<i32>() {
+            let _ = output.send((value, max)).await;
+        }
+    }
+    Ok(())
+}
+
+/// Listens for UPower `OnBattery` property changes. Emits (percent, on_battery, charging)
+/// so the OSD can pop up a status modal when the AC adapter is plugged/unplugged.
+fn battery_status_subscription() -> cosmic::iced::Subscription<(u32, bool, bool)> {
+    use cosmic::iced::futures::{SinkExt, channel::mpsc, stream::StreamExt};
+    use std::hash::Hash;
+    #[derive(Clone)]
+    struct Id;
+    impl Hash for Id {
+        fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
+    }
+    cosmic::iced::Subscription::run_with(Id, |_| {
+        let (tx, rx) = mpsc::channel::<(u32, bool, bool)>(4);
+        tokio::spawn(async move {
+            let mut tx = tx;
+            loop {
+                if let Err(e) = listen_upower_ac(&mut tx).await {
+                    log::warn!("upower ac listener error: {e}");
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                }
+            }
+        });
+        rx.boxed()
+    })
+}
+
+async fn listen_upower_ac(
+    output: &mut cosmic::iced::futures::channel::mpsc::Sender<(u32, bool, bool)>,
+) -> zbus::Result<()> {
+    use cosmic::iced::futures::{SinkExt, StreamExt};
+    let conn = zbus::Connection::system().await?;
+    let proxy = zbus::Proxy::new(
+        &conn,
+        "org.freedesktop.UPower",
+        "/org/freedesktop/UPower",
+        "org.freedesktop.UPower",
+    )
+    .await?;
+    // Emit initial state so the app tracks it
+    let on_battery: bool = proxy.get_property("OnBattery").await.unwrap_or(false);
+    let (pct, charging) = get_display_device_state(&conn).await.unwrap_or((0, false));
+    let _ = output.send((pct, on_battery, charging)).await;
+
+    let mut changes = proxy.receive_property_changed::<bool>("OnBattery").await;
+    while let Some(change) = changes.next().await {
+        let on_battery = change.get().await.unwrap_or(false);
+        let (pct, charging) = get_display_device_state(&conn).await.unwrap_or((0, false));
+        let _ = output.send((pct, on_battery, charging)).await;
+    }
+    Ok(())
+}
+
+async fn get_display_device_state(
+    conn: &zbus::Connection,
+) -> zbus::Result<(u32, bool)> {
+    let dev_proxy = zbus::Proxy::new(
+        conn,
+        "org.freedesktop.UPower",
+        "/org/freedesktop/UPower/devices/DisplayDevice",
+        "org.freedesktop.UPower.Device",
+    )
+    .await?;
+    let pct: f64 = dev_proxy.get_property("Percentage").await.unwrap_or(0.0);
+    let state: u32 = dev_proxy.get_property("State").await.unwrap_or(0);
+    // State 1 = Charging
+    Ok((pct.round() as u32, state == 1))
 }

--- a/src/components/osd_indicator.rs
+++ b/src/components/osd_indicator.rs
@@ -32,6 +32,9 @@ pub enum Params {
     SourceVolume(u32, bool),
     AirplaneMode(bool),
     TouchpadEnabled(TouchpadOverride),
+    /// Battery power status on AC plug/unplug.
+    /// (percent 0-100, on_battery, charging)
+    BatteryStatus(u32, bool, bool),
 }
 
 impl Params {
@@ -74,6 +77,28 @@ impl Params {
             }
             Self::TouchpadEnabled(TouchpadOverride::None) => "input-touchpad-symbolic",
             Self::TouchpadEnabled(TouchpadOverride::ForceDisable) => "touchpad-disabled-symbolic",
+            Self::BatteryStatus(pct, on_battery, charging) => {
+                if !on_battery || *charging {
+                    // Plugged in / charging
+                    match pct {
+                        0..=10 => "battery-level-10-charging-symbolic",
+                        11..=30 => "battery-level-30-charging-symbolic",
+                        31..=50 => "battery-level-50-charging-symbolic",
+                        51..=70 => "battery-level-70-charging-symbolic",
+                        71..=90 => "battery-level-90-charging-symbolic",
+                        _ => "battery-level-100-charged-symbolic",
+                    }
+                } else {
+                    match pct {
+                        0..=10 => "battery-level-10-symbolic",
+                        11..=30 => "battery-level-30-symbolic",
+                        31..=50 => "battery-level-50-symbolic",
+                        51..=70 => "battery-level-70-symbolic",
+                        71..=90 => "battery-level-90-symbolic",
+                        _ => "battery-level-100-symbolic",
+                    }
+                }
+            }
         }
     }
 
@@ -112,6 +137,7 @@ impl Params {
             Self::TouchpadEnabled(_) => None,
             Self::DisplayToggle(_) => None,
             Self::DisplayNumber(_) => None,
+            Self::BatteryStatus(pct, _, _) => Some(*pct),
         }
     }
 }

--- a/src/components/osd_indicator.rs
+++ b/src/components/osd_indicator.rs
@@ -3,7 +3,6 @@
 
 use crate::components::app::DisplayMode;
 use crate::config;
-use cosmic::cctk::sctk::seat::input_method_v3::Rectangle;
 use cosmic::iced::platform_specific::shell::commands::layer_surface::{
     Anchor, KeyboardInteractivity, Layer, destroy_layer_surface, get_layer_surface,
 };
@@ -22,6 +21,17 @@ use std::time::Duration;
 pub static OSD_INDICATOR_ID: LazyLock<widget::Id> =
     LazyLock::new(|| widget::Id::new("osd-indicator".to_string()));
 
+/// Coarse classification of an audio output for picking a meaningful OSD icon.
+/// Derived from the default-sink node name reported by PulseAudio/PipeWire
+/// (e.g. `bluez_output.*` → `Bluetooth`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SinkKind {
+    #[default]
+    Speaker,
+    Headphones,
+    Bluetooth,
+}
+
 #[derive(Debug)]
 pub enum Params {
     DisplayBrightness(f64),      // Rung ratio k/20.0 (hotkeys)
@@ -29,10 +39,14 @@ pub enum Params {
     DisplayToggle(DisplayMode),
     DisplayNumber(u32),
     KeyboardBrightness(f64),
-    SinkVolume(u32, bool),
+    /// (volume %, muted, output device kind)
+    SinkVolume(u32, bool, SinkKind),
     SourceVolume(u32, bool),
     AirplaneMode(bool),
     TouchpadEnabled(TouchpadOverride),
+    /// Battery power status on AC plug/unplug.
+    /// (percent 0-100, on_battery, charging)
+    BatteryStatus(u32, bool, bool),
 }
 
 impl Params {
@@ -49,17 +63,29 @@ impl Params {
             Self::KeyboardBrightness(_) => "keyboard-brightness-symbolic",
             Self::AirplaneMode(true) => "airplane-mode-symbolic",
             Self::AirplaneMode(false) => "airplane-mode-disabled-symbolic",
-            Self::SinkVolume(volume, muted) => {
+            Self::SinkVolume(volume, muted, kind) => {
                 if *volume == 0 || *muted {
                     "audio-volume-muted-symbolic"
-                } else if *volume < 33 {
-                    "audio-volume-low-symbolic"
-                } else if *volume < 66 {
-                    "audio-volume-medium-symbolic"
-                } else if *volume <= 100 {
-                    "audio-volume-high-symbolic"
                 } else {
-                    "audio-volume-overamplified-symbolic"
+                    // For non-speaker outputs, prefer a device-shape icon over the
+                    // generic speaker family — the speaker silhouette is misleading
+                    // when audio is going to headphones/Bluetooth.
+                    match kind {
+                        SinkKind::Bluetooth | SinkKind::Headphones => {
+                            "audio-headphones-symbolic"
+                        }
+                        SinkKind::Speaker => {
+                            if *volume < 33 {
+                                "audio-volume-low-symbolic"
+                            } else if *volume < 66 {
+                                "audio-volume-medium-symbolic"
+                            } else if *volume <= 100 {
+                                "audio-volume-high-symbolic"
+                            } else {
+                                "audio-volume-overamplified-symbolic"
+                            }
+                        }
+                    }
                 }
             }
             Self::SourceVolume(volume, muted) => {
@@ -75,6 +101,28 @@ impl Params {
             }
             Self::TouchpadEnabled(TouchpadOverride::None) => "input-touchpad-symbolic",
             Self::TouchpadEnabled(TouchpadOverride::ForceDisable) => "touchpad-disabled-symbolic",
+            Self::BatteryStatus(pct, on_battery, charging) => {
+                if !on_battery || *charging {
+                    // Plugged in / charging
+                    match pct {
+                        0..=10 => "battery-level-10-charging-symbolic",
+                        11..=30 => "battery-level-30-charging-symbolic",
+                        31..=50 => "battery-level-50-charging-symbolic",
+                        51..=70 => "battery-level-70-charging-symbolic",
+                        71..=90 => "battery-level-90-charging-symbolic",
+                        _ => "battery-level-100-charged-symbolic",
+                    }
+                } else {
+                    match pct {
+                        0..=10 => "battery-level-10-symbolic",
+                        11..=30 => "battery-level-30-symbolic",
+                        31..=50 => "battery-level-50-symbolic",
+                        51..=70 => "battery-level-70-symbolic",
+                        71..=90 => "battery-level-90-symbolic",
+                        _ => "battery-level-100-symbolic",
+                    }
+                }
+            }
         }
     }
 
@@ -105,14 +153,15 @@ impl Params {
                 Some(p as u32)
             }
             Self::KeyboardBrightness(value) => Some((*value * 100.) as u32),
-            Self::SinkVolume(_, true) => Some(0),
+            Self::SinkVolume(_, true, _) => Some(0),
             Self::SourceVolume(_, true) => Some(0),
-            Self::SinkVolume(value, false) => Some(*value),
+            Self::SinkVolume(value, false, _) => Some(*value),
             Self::SourceVolume(value, false) => Some(*value),
             Self::AirplaneMode(_) => None,
             Self::TouchpadEnabled(_) => None,
             Self::DisplayToggle(_) => None,
             Self::DisplayNumber(_) => None,
+            Self::BatteryStatus(pct, _, _) => Some(*pct),
         }
     }
 }
@@ -280,7 +329,7 @@ impl State {
 
     fn max_value(&self) -> f32 {
         match self.params {
-            Params::SinkVolume(_, _) if self.amplification_sink => 150.0,
+            Params::SinkVolume(_, _, _) if self.amplification_sink => 150.0,
             Params::SourceVolume(_, _) if self.amplification_source => 150.0,
             _ => 100.0,
         }


### PR DESCRIPTION
## Summary

Two related additions to the OSD daemon:

* **Hotkey-only brightness OSD** — subscribes to a new `DisplayBrightnessHotkey` D-Bus signal from `cosmic-settings-daemon` (pop-os/cosmic-settings-daemon#144) so the brightness slider only appears when the user actually pressed a brightness key. The default property-change subscription fires on every backlight write, including programmatic ones (dim-on-idle, accessibility tooling, screen savers), which currently makes the OSD pop up every time the screen is about to sleep. This PR keeps the existing property subscription, but adds the hotkey signal as the canonical user-facing trigger so the OSD can suppress noisy programmatic writes cleanly when paired with that daemon change.
* **Battery AC plug/unplug indicator** — a small status pill that appears when the AC adapter is connected/disconnected, showing the current battery percentage and charging state. Uses the standard UPower interface; new `BatteryStatus` subscription on the app side, new `Params::BatteryStatus(percentage, charging, plugged)` variant in `osd_indicator` that maps to the appropriate `battery-*-symbolic` icon and renders the percentage value.

## Motivation

* **Hotkey signal**: paired with the `cosmic-idle` dim-on-idle PR (pop-os/cosmic-idle), the brightness OSD currently flashes once per fade frame as the backlight is being lowered. There's no clean way today for the OSD to tell *who* wrote the value. A separate signal for the user-facing path solves this without changing existing behaviour for clients that don't subscribe to it.
* **Battery indicator**: nice ergonomic touch — gives feedback when you plug/unplug a laptop charger without needing to glance at the panel. Mirrors the volume/brightness OSD pattern.

## Implementation

* `src/components/app.rs`:
  * `Msg::HotkeyBrightness(u32)` and a `hotkey_brightness_subscription` that listens for the new daemon signal.
  * `Msg::BatteryStatus { percentage, charging, plugged }` and a `battery_status_subscription` that watches UPower's `org.freedesktop.UPower.Device` properties for `state` / `percentage` changes on the primary display device.
* `src/components/osd_indicator.rs`:
  * New `Params::BatteryStatus(percentage, charging, plugged)` variant.
  * Icon selection: `battery-{level}{-charging}-symbolic` based on percentage bucket and charging flag, falling back to the symbolic family already used for volume/brightness.

## Testing

Daily-driven for several weeks. Hotkey signal verified by tapping the brightness keys vs. running a backlight fader programmatically — only the former pops the OSD. Battery indicator verified by plugging/unplugging the charger.

## Dependencies

The hotkey path requires pop-os/cosmic-settings-daemon#144. The battery indicator is independent — happy to split that into a separate PR if maintainers prefer to review them apart.

## AI Disclosure

Patches were drafted with assistance from Claude (Anthropic). Commits include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` trailers. I understand each change and will respond to review feedback. I'm aware of the AI-PR policy in the template — happy to rework or close if maintainers prefer.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.