### PR TITLE
Fix Brightness OSD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-daemon-subscription"
 version = "1.0.7"
-source = "git+https://github.com/pop-os/cosmic-settings#78644a32e3741f8f80e9b8ce65c3550c85f9c1f8"
+source = "git+https://github.com/pop-os/cosmic-settings#81912bed6cdebe2719e29e6bd1453e7b977acb0e"
 dependencies = [
  "futures",
  "iced_futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cosmic-osd"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.90"
+rust-version = "1.93"
 license = "GPL-3.0-or-later"
 
 [dependencies]


### PR DESCRIPTION
- [x] Depends on https://github.com/pop-os/cosmic-settings/pull/2013

Brightness OSD does not show up on my laptop anymore.
Waiting for cosmic-settings-daemon and sending initial value for max-brightness fixes the issue.

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

