### PR TITLE
fix(audio): accessing sink volume array when checking source volume

### DIFF
--- a/src/components/audio/model.rs
+++ b/src/components/audio/model.rs
@@ -93,7 +93,7 @@ impl Model {
                         && let Some(pos) = self.sources.active
                     {
                         let changed = self.active_source.mute != self.sources.mute[pos]
-                            || self.active_source.volume != self.sinks.volume[pos];
+                            || self.active_source.volume != self.sources.volume[pos];
                         self.active_source.mute = self.sources.mute[pos];
                         self.active_source.volume = self.sources.volume[pos];
                         return changed.then_some(Response::SourceVolume(


### PR DESCRIPTION
Source node arrays are being compared by index but the sink volume array is being accessed instead.

---
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

