### PR TITLE
fix: start the object server on the com.system76.CosmicOsd connection

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+name: "🎉 Release"
+
+on:
+  workflow_dispatch:
+    inputs: {}
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  run-tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Task
+        uses: go-task/setup-task@v1
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+      - run: |
+          npm install @semantic-release/exec @semantic-release/git @semantic-release/changelog @semantic-release/github
+      - run: |
+          task release
+          if [ ! -d dist ] || [ -z "$(ls -A dist 2>/dev/null)" ]; then
+            echo "No release was created - no relevant changes found"
+            exit 0
+          fi
+          export VERSION=$(ls dist | head -n 1 | cut -d'-' -f3)
+          task repo:update ARCH=x86_64 VERSION=$VERSION
+          task repo:update ARCH=aarch64 VERSION=$VERSION
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SSH_KEY: ${{ secrets.BITBUCKET_SSH_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          PACKAGES_UPLOAD_TOKEN: ${{ secrets.PACKAGES_UPLOAD_TOKEN }}

--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -1,0 +1,66 @@
+name: Rust Checks
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libxkbcommon-dev libfontconfig1-dev libfreetype6-dev libglvnd-dev libinput-dev libvulkan-dev libwayland-dev libx11-dev libxcursor-dev libxi-dev libxrandr-dev libasound2-dev libdbus-1-dev
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libxkbcommon-dev libfontconfig1-dev libfreetype6-dev libglvnd-dev libinput-dev libvulkan-dev libwayland-dev libx11-dev libxcursor-dev libxi-dev libxrandr-dev libasound2-dev libdbus-1-dev
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Run Tests
+        run: cargo test --all-targets --all-features

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,53 @@
+name: 🪲 Test
+
+on:
+  push:
+    branches-ignore:
+      - master
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run-tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Task
+        uses: go-task/setup-task@v1
+      - uses: actions/checkout@v3
+      - run: |
+          task docker:run TARGET='test:all'
+        env:
+          SSH_KEY: ${{ secrets.BITBUCKET_SSH_KEY }}
+
+  build-x86_64:
+    name: Run x86_64 build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Task
+        uses: go-task/setup-task@v1
+      - uses: actions/checkout@v3
+      - run: |
+          task docker:run TARGET=dist:all ARCH=x86_64 TARGET_ARCH=x86_64-unknown-linux-gnu
+        env:
+          SSH_KEY: ${{ secrets.BITBUCKET_SSH_KEY }}
+
+  build-aarch64:
+    name: Run aarch64 build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Task
+        uses: go-task/setup-task@v1
+      - uses: actions/checkout@v3
+      - run: |
+          task docker:run TARGET=dist:all ARCH=aarch64 TARGET_ARCH=aarch64-unknown-linux-gnu
+        env:
+          SSH_KEY: ${{ secrets.BITBUCKET_SSH_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ debian/*
 !debian/rules
 !debian/source
 !debian/install
+.cache/
+dist/
+.task

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,55 @@
+# Semantic Release Configuration
+# https://semantic-release.gitbook.io/semantic-release/usage/configuration
+
+# Any merges into branches that match these patterns will trigger a release.
+branches:
+  - name: master
+  #- name: 'v+([0-9])?(.{+([0-9]),x}).x'
+
+# These plugins will run when a release is triggered. They will analyze commit
+# messages to determine what kind of release this is and publish a new release.
+plugins:
+  # Analyze commit messages to determine next version
+  - "@semantic-release/commit-analyzer"
+
+  # Generate release notes
+  - "@semantic-release/release-notes-generator"
+
+  # Generate release notes
+  - - "@semantic-release/changelog"
+    - changelogFile: CHANGELOG.md
+
+  # Replace version strings in the project. The 'git' plugin is needed to
+  # commit the version strings to the repository.
+  # Using exec + sed for Cargo.toml to only replace the FIRST version match (package version)
+  # The replace plugin would replace ALL matches including dependency versions
+  - - "@semantic-release/exec"
+    - shell: true
+      prepareCmd: |
+        sed -i '0,/^version = "[0-9]\+\.[0-9]\+\.[0-9]\+"$/s//version = "${nextRelease.version}"/' Cargo.toml
+        sed -i 's/^Version: .*/Version: ${nextRelease.version}/' pkg/rpm/cosmic-osd.spec
+        task docker:run TARGET=dist:all ARCH=x86_64 TARGET_ARCH=x86_64-unknown-linux-gnu
+        task docker:run TARGET=dist:all ARCH=aarch64 TARGET_ARCH=aarch64-unknown-linux-gnu
+
+  # Commit the following changes to git after other plugins have run
+  - - "@semantic-release/git"
+    - assets:
+        - CHANGELOG.md
+        - Cargo.toml
+        - Cargo.lock
+        - pkg/rpm/cosmic-osd.spec
+
+  # Create a GitHub release with RPM assets
+  - - "@semantic-release/github"
+    - assets:
+        - path: "dist/*x86_64*.rpm"
+          label: "RPM (x86_64)"
+        - path: "dist/*aarch64*.rpm"
+          label: "RPM (aarch64)"
+      # This is a fork that syncs upstream (pop-os/cosmic-osd). Synced commits
+      # carry "Merge pull request #NNN" references to PRs that exist upstream but
+      # not in this fork, so the post-release success/fail steps 404 when they try
+      # to comment on those PRs/issues. Disable PR/issue commenting entirely.
+      successComment: false
+      failComment: false
+      failTitle: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,52 @@
+# 1.0.0 (2026-07-24)
+
+
+### Bug Fixes
+
+* **audio:** accessing sink volume array when checking source volume ([4e60034](https://github.com/playtron-os/cosmic-osd/commit/4e60034f0574e079c5577097a8a1ebeb3e7acf96))
+* cleanup osd using helper ([c548cb6](https://github.com/playtron-os/cosmic-osd/commit/c548cb6faac256c5aaa59e3c975dc4bed8e35b0b))
+* ensure no input is blocked by the osd indicator ([d7b4c88](https://github.com/playtron-os/cosmic-osd/commit/d7b4c8851c53b5593344c6f701186a20f82be782))
+* focus cancel button after surface gains focus ([9e5e330](https://github.com/playtron-os/cosmic-osd/commit/9e5e3309172575b2ef18a775ba1520986c8d9853))
+* focus cancel button after surface gains focus ([#185](https://github.com/playtron-os/cosmic-osd/issues/185)) ([e2c680e](https://github.com/playtron-os/cosmic-osd/commit/e2c680ed1cf7271fb4abfcffb72ebfeac0d76f09))
+* focus polkit dialog text input ([2d8a84a](https://github.com/playtron-os/cosmic-osd/commit/2d8a84a95e1459a19aa0d967bcecca1a6a5df139))
+* handle activation when already prompting for confirmation ([cd3d568](https://github.com/playtron-os/cosmic-osd/commit/cd3d5681973b606437f672c45d526f2b622e61d8))
+* handling of simultaneous surfaces and dummy surface ([7190b6a](https://github.com/playtron-os/cosmic-osd/commit/7190b6a99e5175d4b102e4dd550f8c88f7d01247))
+* **headset:** if headset is chosen, force the port of the default source for the preffered headset profile ([aa8a7d5](https://github.com/playtron-os/cosmic-osd/commit/aa8a7d5a01489bbf56e33f45abcadf1e497d7757))
+* **headset:** set source if headset selected ([c26ecb0](https://github.com/playtron-os/cosmic-osd/commit/c26ecb025ddd3c778bd39a37739dce507933d680))
+* **libcosmic:** theme subscription ([8eb1210](https://github.com/playtron-os/cosmic-osd/commit/8eb1210dfac37d426a6bc86ae56b2a445ced3251))
+* match volume icons to volume applet ([3063271](https://github.com/playtron-os/cosmic-osd/commit/30632719fee6e3a0fb10ccdea53052e8b97a9bc0))
+* patch deps ([9f8f6a5](https://github.com/playtron-os/cosmic-osd/commit/9f8f6a55b294a78037621e10d582febc6bc16369))
+* polkit agent not working with sockets ([cb9698c](https://github.com/playtron-os/cosmic-osd/commit/cb9698c8536df05b7086115a071a3d3838b245f2))
+* start the object server on the com.system76.CosmicOsd connection ([1e82a99](https://github.com/playtron-os/cosmic-osd/commit/1e82a9914ae043fbbec73a00d30c7dee35a1986f))
+* surface cleanup ([c57df29](https://github.com/playtron-os/cosmic-osd/commit/c57df29816e9647bfe85086eae301da9671c21d8))
+* update iced ([9588584](https://github.com/playtron-os/cosmic-osd/commit/95885844d35468feb0e39a82c7b829371f606cd6))
+* use xdg base dir to locate volume change file ([4970139](https://github.com/playtron-os/cosmic-osd/commit/4970139d875f9b28ea72d431e07ca3650a200470))
+
+
+### Features
+
+* add rpm deployment config and CI ([b6f33e5](https://github.com/playtron-os/cosmic-osd/commit/b6f33e56caea68490227b9b1c328bd96ed1f4c7d))
+* apply transparency to the colors ([48b46c9](https://github.com/playtron-os/cosmic-osd/commit/48b46c9b367dff551499403fe237c9e23c6c95d7))
+* avoid overlap with panel ([5d6faf9](https://github.com/playtron-os/cosmic-osd/commit/5d6faf9fd99a548774c0ee2ed1ff66e87c6500ce))
+* blur for osd indicator surfaces ([4bfdb53](https://github.com/playtron-os/cosmic-osd/commit/4bfdb5311a144d9c6aff102dc251e5be93f7579e))
+* confirm headphone / headset ([6fd6a53](https://github.com/playtron-os/cosmic-osd/commit/6fd6a53c606da5ff1bbb6f7101bcacd76f2d2267))
+* display toggle ([1b2e475](https://github.com/playtron-os/cosmic-osd/commit/1b2e475b1616ea791aa998967f6317460aa373eb))
+* enter-bios confirmation dialog ([fa52300](https://github.com/playtron-os/cosmic-osd/commit/fa52300823ffe0d0cf9764c473d9231642037710))
+* improve handling of blur on creation and tracking of overlaps ([8d66849](https://github.com/playtron-os/cosmic-osd/commit/8d66849f7e015e1c9fc428852e4ddaed691cec2e))
+* new progress bar animations & min button width fix ([cbc1e9c](https://github.com/playtron-os/cosmic-osd/commit/cbc1e9cbf3af02faf8caa471dddcb03b98cd5f55))
+* osd indicator for touchpad toggle ([720742c](https://github.com/playtron-os/cosmic-osd/commit/720742cc5289d81fb50d65097109e8664b9d505a))
+* **osd_indicator:** respect amplification config ([63cbfa8](https://github.com/playtron-os/cosmic-osd/commit/63cbfa873bdd9fb1eda335e37408948fc0058906))
+* play sound on sink volume change ([789698e](https://github.com/playtron-os/cosmic-osd/commit/789698e6d074d96fc502a5ee8bffba679dbca8a8))
+* popups for log out, restart, and shutdown ([9b4e2be](https://github.com/playtron-os/cosmic-osd/commit/9b4e2bebbf8cf39c49c6dfa021afbcf49e1fd777))
+* **sound:** use cosmic-settings-daemon's varlink API ([61063ff](https://github.com/playtron-os/cosmic-osd/commit/61063ffbdb777f3305998eee2a31f4afd75f2cde))
+
+
+### Performance Improvements
+
+* optimized cosmic-freedesktop-icons ([93ac12d](https://github.com/playtron-os/cosmic-osd/commit/93ac12d186e4e69cc0decfdc259c04633420b69a))
+* update freedesktop-icons to reduce memory usage ([49ab688](https://github.com/playtron-os/cosmic-osd/commit/49ab688d3e679077d9bfdb6ea8ccfb657102721b))
+* update libcosmic for reduced memory usage ([2abc7ad](https://github.com/playtron-os/cosmic-osd/commit/2abc7adf59c20fdc0b7e6391518711e760014462))
+
 # Changelog
 
 All notable changes to this project will be documented in this file. See

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See
+[semantic-release](https://github.com/semantic-release/semantic-release) for
+commit conventions; entries below are generated on release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-osd"
-version = "1.2.0"
+version = "1.0.0"
 dependencies = [
  "clap",
  "cosmic-comp-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-osd"
-version = "0.1.0"
+version = "1.2.0"
 dependencies = [
  "clap",
  "cosmic-comp-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmic-osd"
-version = "1.2.0"
+version = "1.0.0"
 edition = "2024"
 rust-version = "1.93"
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmic-osd"
-version = "0.1.0"
+version = "1.2.0"
 edition = "2024"
 rust-version = "1.93"
 license = "GPL-3.0-or-later"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
-ARG version=1.96
+# Rust version MUST match rust-toolchain.toml's channel pin. The build switches to
+# the pinned toolchain inside the mounted repo, so `rustup target add` below has to
+# target that same version or the aarch64 std ends up missing (E0463 core/std).
+ARG version=1.93.0
 FROM rust:${version}
 ARG version
 
 RUN dpkg --add-architecture arm64
 RUN apt-get update && apt-get install -y \
     cmake \
+    pkg-config \
+    git \
+    ca-certificates \
     libclang-dev \
+    libudev-dev \
+    libudev-dev:arm64 \
+    libinput-dev \
+    libinput-dev:arm64 \
     libxkbcommon-dev \
     libxkbcommon-dev:arm64 \
     libssl-dev \
@@ -22,10 +32,16 @@ RUN apt-get install -y task
 # RPM support
 RUN apt-get install -y rpm librpmbuild10 elfutils
 
-RUN rustup target add aarch64-unknown-linux-gnu
+# Install the aarch64 std for the PINNED toolchain ($version), not just the image
+# default — mirrors cosmic-comp, which builds the same libudev/libinput deps.
+RUN rustup target add --toolchain $version aarch64-unknown-linux-gnu
+RUN rustup toolchain install --force-non-host $version-aarch64-unknown-linux-gnu
 RUN rustup component add clippy
 RUN chmod -R 777 /usr/local/rustup
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 ENV CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
 ENV CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
+
+# Retry transient network failures (crates.io / git deps) instead of failing the build
+ENV CARGO_NET_RETRY=10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+ARG version=1.96
+FROM rust:${version}
+ARG version
+
+RUN dpkg --add-architecture arm64
+RUN apt-get update && apt-get install -y \
+    cmake \
+    libclang-dev \
+    libxkbcommon-dev \
+    libxkbcommon-dev:arm64 \
+    libssl-dev \
+    libssl-dev:arm64
+
+RUN apt-get install -y \
+    g++-aarch64-linux-gnu \
+    libc6-dev-arm64-cross
+
+# Taskfile support
+RUN curl -1sLf 'https://dl.cloudsmith.io/public/task/task/setup.deb.sh' | bash
+RUN apt-get install -y task
+
+# RPM support
+RUN apt-get install -y rpm librpmbuild10 elfutils
+
+RUN rustup target add aarch64-unknown-linux-gnu
+RUN rustup component add clippy
+RUN chmod -R 777 /usr/local/rustup
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+ENV CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+ENV CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,219 @@
+version: "3"
+
+vars:
+  NAME:
+    sh: grep 'name =' Cargo.toml | head -n 1 | cut -d'"' -f2
+  VERSION:
+    sh: grep '^version =' Cargo.toml | head -n 1 | cut -d'"' -f2
+  HOST_OS:
+    sh: uname
+  HOST_ARCH:
+    sh: uname -m
+  TARGET_ARCH:
+    sh: "rustc -vV | sed -n 's/host: //p'"
+  ARCH:
+    sh: echo "{{.TARGET_ARCH}}" | cut -d'-' -f1
+  IMAGE_NAME: "{{.NAME}}-builder"
+  IMAGE_TAG:
+    sh: sha256sum Dockerfile | cut -d' ' -f1
+
+tasks:
+  default:
+    aliases:
+      - help
+    cmds:
+      - go-task --list
+
+  build:debug:
+    desc: Build debug build
+    cmds:
+      - cargo build {{.ARG | default ""}} --target {{.TARGET_ARCH}}
+
+  build:release:
+    desc: Build release build
+    aliases:
+      - build
+    cmds:
+      - cargo build --release --target {{.TARGET_ARCH}}
+
+  build:all:
+    desc: Build release and debug builds
+    deps:
+      - build:debug
+      - build:release
+
+  run:
+    deps:
+      - build:debug
+    requires:
+      vars:
+        - name: LOG_LEVEL
+          enum: [trace, debug, info]
+    vars:
+      LOG_LEVEL: '{{.LOG_LEVEL | default "info"}}'
+    env:
+      RUST_LOG: |-
+        {{- if eq .LOG_LEVEL "trace" }}
+        error,cosmic_osd=trace
+        {{- else if eq .LOG_LEVEL "debug" }}
+        error,cosmic_osd=debug
+        {{- else }}
+        error,cosmic_osd=info
+        {{- end }}
+    cmds:
+      - ./target/{{.TARGET_ARCH}}/debug/{{.NAME}}
+
+  dist:prepare:
+    desc: Prepare the project for packaging
+    deps:
+      - build:release
+    cmds:
+      - rm -rf .cache/{{.NAME}}
+      - mkdir -p .cache/{{.NAME}}/usr/bin
+      - install -Dm0755 "target/{{.TARGET_ARCH}}/release/{{.NAME}}" ".cache/{{.NAME}}/usr/bin/{{.NAME}}"
+      - install -Dm0644 "LICENSE" ".cache/{{.NAME}}/usr/share/licenses/{{.NAME}}/LICENSE"
+      - mkdir -p dist
+
+  dist:archive:
+    desc: Build a tar archive of the project
+    deps:
+      - dist:prepare
+    cmds:
+      - tar cvfz dist/{{.NAME}}-{{.ARCH}}.tar.gz -C .cache {{.NAME}}
+
+  dist:rpm:
+    desc: Build an RPM package
+    aliases:
+      - rpm
+    deps:
+      - dist:archive
+    preconditions:
+      - sh: which rpmbuild
+        msg: "Prerequisite utility 'rpmbuild' is not installed"
+    cmds:
+      - mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+      - cp ./pkg/rpm/{{.NAME}}.spec ~/rpmbuild/SPECS
+      - cp dist/{{.NAME}}-{{.ARCH}}.tar.gz ~/rpmbuild/SOURCES
+      - rpmbuild -bb --target {{.ARCH}} ~/rpmbuild/SPECS/{{.NAME}}.spec
+      # glob the release field so a local Fedora build (dist tag, e.g. .fc44) is
+      # matched as well as the tagless Debian/CI container build.
+      - cp ~/rpmbuild/RPMS/{{.ARCH}}/{{.NAME}}-{{.VERSION}}-1*.{{.ARCH}}.rpm dist
+
+  dist:all:
+    desc: Build all supported distributable packages
+    aliases:
+      - dist
+    cmds:
+      - task: dist:archive
+      - task: dist:rpm
+
+  release:
+    desc: Publish a new release
+    preconditions:
+      - sh: which npx
+        msg: "Prerequisite utility 'npx' is not installed"
+    cmds:
+      # The .releaserc.yaml config contains the build commands and publish config
+      - npx semantic-release
+
+  repo:update:
+    desc: "Upload the release to the package repository"
+    vars:
+      BUCKET: playtron-dev2-global-os-public
+      BUCKET_PATH: repos/playtron-app/{{.ARCH}}
+      FILE: "dist/{{.NAME}}-{{.VERSION}}-1.{{.ARCH}}.rpm"
+      REPO_NAME: playtron
+    preconditions:
+      - sh: ls {{.FILE}}
+        msg: "File to upload does not exist: {{.FILE}}"
+      - sh: env | grep -q '^PACKAGES_UPLOAD_TOKEN='
+        msg: "PACKAGES_UPLOAD_TOKEN environment variable is not set"
+    cmds:
+      # TODO: Remove S3 uploads after repository switch
+      - echo "Uploading {{.FILE}} to s3://{{.BUCKET}}/{{.BUCKET_PATH}}/$(basename {{.FILE}})"
+      - aws s3 cp {{.FILE}} s3://{{.BUCKET}}/{{.BUCKET_PATH}}/$(basename "{{.FILE}}")
+      - echo "Publishing {{.FILE}} to 'https://packages.playtron.one/rpm/{{.REPO_NAME}}/packages/{{.NAME}}-{{.VERSION}}-1.{{.ARCH}}.rpm'"
+      - "curl -H 'Authorization: Bearer {{.PACKAGES_UPLOAD_TOKEN}}' -T {{.FILE}} 'https://packages.playtron.one/rpm/{{.REPO_NAME}}/packages/{{.NAME}}-{{.VERSION}}-1.{{.ARCH}}.rpm'"
+
+  test:all:
+    desc: Run all tests
+    aliases:
+      - test
+    cmds:
+      - cargo test -- --show-output
+
+  test:one:
+    desc: Run a single test - E.g. go-task test:one TEST=<test>
+    requires:
+      vars:
+        - TEST
+    cmds:
+      - RUST_BACKTRACE=1 cargo test {{.TEST}} -- --exact --show-output --include-ignored
+
+  clean:
+    desc: Remove build artifacts
+    cmds:
+      - rm -rf target .cache dist builder
+
+  docker:build:
+    desc: Build the container image used for the `docker:run` target
+    preconditions:
+      - sh: which docker
+        msg: "Prerequisite utility 'docker' is not installed"
+    status:
+      - docker images | grep {{.IMAGE_NAME}} | grep {{.IMAGE_TAG}}
+    cmds:
+      - docker build -t {{.IMAGE_NAME}}:{{.IMAGE_TAG}} .
+
+  docker:run:
+    desc: Run tasks inside Docker. E.g. go-task docker:run TARGET=build TARGET_ARCH=x86_64-unknown-linux-gnu
+    aliases:
+      - in-docker
+    deps:
+      - docker:build
+    preconditions:
+      - sh: which docker
+        msg: "Prerequisite utility 'docker' is not installed"
+    vars:
+      UID:
+        sh: id -u
+      GID:
+        sh: id -g
+      PWD:
+        sh: pwd
+      SSH_KEY:
+        sh: echo "${SSH_KEY}"
+    requires:
+      vars:
+        - TARGET
+    cmds:
+      - mkdir -p .cache/home
+      - mkdir -p .cache/var/lib/rpm
+      # A /etc/passwd entry is required so the correct ~/.ssh path is used
+      - echo -e "build:x:{{.UID}}:{{.GID}}::/home/build:/bin/bash" > .cache/passwd
+      # Use the SSH key from the host
+      - |
+        mkdir -p .cache/.ssh
+        {{ if ne .SSH_KEY "" }}
+          echo "{{.SSH_KEY}}" > .cache/.ssh/id_ed25519
+          chmod 600 .cache/.ssh/id_ed25519
+        {{ else }}
+          cp ~/.ssh/* .cache/.ssh
+        {{ end }}
+      - |
+        docker run --rm \
+          -v "{{.PWD}}:{{.PWD}}" \
+          -v "{{.PWD}}/.cache/home:/home/build" \
+          -v "{{.PWD}}/.cache/var/lib/rpm:/var/lib/rpm" \
+          -v "{{.PWD}}/.cache/.ssh:/home/build/.ssh" \
+          -v "{{.PWD}}/.cache/passwd:/etc/passwd" \
+          --workdir "{{.PWD}}" \
+          -e HOME=/home/build \
+          -e CARGO_HOME=/home/build/.cargo \
+          -e BUILD_TYPE=${BUILD_TYPE} \
+          -e PKG_CONFIG_SYSROOT_DIR="/usr/{{.ARCH}}-linux-gnu" \
+          -e CARGO_NET_GIT_FETCH_WITH_CLI=true \
+          -e GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
+          --user {{.UID}}:{{.GID}} \
+          {{.IMAGE_NAME}}:{{.IMAGE_TAG}} \
+          task {{.TARGET}} ARCH={{.ARCH}} TARGET_ARCH={{.TARGET_ARCH}}

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 name := 'cosmic-osd'
 rootdir := ''
 prefix := '/usr'
-polkit-agent-helper-1 := '/usr/libexec/polkit-agent-helper-1'
+polkit-agent-helper-1 := '/usr/lib/polkit-1/polkit-agent-helper-1'
 cargo-target-dir := env('CARGO_TARGET_DIR', 'target')
 
 base-dir := absolute_path(clean(rootdir / prefix))

--- a/pkg/rpm/cosmic-osd.spec
+++ b/pkg/rpm/cosmic-osd.spec
@@ -1,0 +1,50 @@
+Name:           cosmic-osd
+Epoch:          1
+Version: 1.2.0
+Release:        1%{?dist}
+Summary:        COSMIC OSD and polkit agent (Playtron fork)
+
+License:        GPL-3.0-only
+URL:            https://github.com/pop-os/cosmic-osd
+Source0:        %{name}-%{_arch}.tar.gz
+
+# Binary is pre-built (see Taskfile dist:prepare); no debuginfo extraction.
+%global debug_package %{nil}
+
+# No BuildRequires - binary is pre-built
+
+# Runtime deps mirror stock cosmic-osd. polkit provides polkit-agent-helper-1
+# (the PAM helper this agent execs); pulseaudio-utils backs the audio OSD;
+# cosmic-icon-theme is the noarch icon set — bind to COSMIC 1.x (< 2.0.0).
+Requires:       polkit
+Requires:       dbus
+Requires:       pulseaudio-utils
+Requires:       (cosmic-icon-theme >= 1.0.0 with cosmic-icon-theme < 2.0.0)
+
+# Override the upstream/stock cosmic-osd. Forked packages carry Epoch:1 so their
+# constraints outrank the stock (epoch-less) Fedora package.
+Provides:       cosmic-osd = %{epoch}:%{version}-%{release}
+Obsoletes:      cosmic-osd < %{epoch}:%{version}
+
+%description
+On-screen display and polkit authentication agent for the COSMIC desktop
+environment. Renders volume/brightness/media OSDs and presents polkit password
+prompts to the user.
+
+%prep
+%autosetup -n %{name} -p1
+
+%build
+
+%install
+install -Dm0755 "usr/bin/cosmic-osd" "%{buildroot}%{_bindir}/cosmic-osd"
+install -Dm0644 "usr/share/licenses/cosmic-osd/LICENSE" "%{buildroot}%{_datadir}/licenses/cosmic-osd/LICENSE"
+
+%files
+%license %{_datadir}/licenses/cosmic-osd/LICENSE
+%{_bindir}/cosmic-osd
+
+%changelog
+* Fri Jul 24 2026 Playtron <dev@playtron.one> - 1.2.0-1
+- Initial RPM package (Playtron fork)
+- Resolve polkit-agent-helper-1 across distro paths (fixes auth prompts on Fedora)

--- a/pkg/rpm/cosmic-osd.spec
+++ b/pkg/rpm/cosmic-osd.spec
@@ -1,6 +1,6 @@
 Name:           cosmic-osd
 Epoch:          1
-Version: 1.2.0
+Version: 1.0.0
 Release:        1%{?dist}
 Summary:        COSMIC OSD and polkit agent (Playtron fork)
 

--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -222,7 +222,9 @@ enum Surface {
 
 pub(crate) struct App {
     core: cosmic::app::Core,
+    #[allow(dead_code)]
     connection: Option<zbus::Connection>,
+    settings_connection: Option<zbus::Connection>,
     system_connection: Option<zbus::Connection>,
     surfaces: HashMap<SurfaceId, Surface>,
     indicator: Option<(SurfaceId, osd_indicator::State)>,
@@ -515,6 +517,7 @@ impl cosmic::Application for App {
         let mut app = Self {
             core,
             connection: None,
+            settings_connection: None,
             system_connection: None,
             surfaces: HashMap::new(),
             indicator: None,
@@ -608,6 +611,9 @@ impl cosmic::Application for App {
             Msg::DBus(event) => {
                 match event {
                     dbus::Event::Connection(connection) => self.connection = Some(connection),
+                    dbus::Event::SettingsConnection(connection) => {
+                        self.settings_connection = Some(connection)
+                    }
                     dbus::Event::SystemConnection(connection) => {
                         self.system_connection = Some(connection)
                     }
@@ -1133,7 +1139,7 @@ impl cosmic::Application for App {
             subscriptions.push(polkit_agent::subscription(connection).map(Msg::PolkitAgent));
         }
 
-        if let Some(connection) = self.connection.clone() {
+        if let Some(connection) = self.settings_connection.clone() {
             subscriptions.push(settings_daemon::subscription(connection).map(Msg::SettingsDaemon));
         }
 

--- a/src/subscriptions/dbus.rs
+++ b/src/subscriptions/dbus.rs
@@ -8,6 +8,7 @@ static NAME: &str = "com.system76.CosmicOsd";
 #[derive(Clone, Debug)]
 pub enum Event {
     Connection(zbus::Connection),
+    SettingsConnection(zbus::Connection),
     SystemConnection(zbus::Connection),
     Error(&'static str, zbus::Error),
 }
@@ -15,6 +16,7 @@ pub enum Event {
 enum State {
     Start,
     CreatedConnection,
+    CreatedSettingsConnection,
     CreatedSystemConnection,
 }
 
@@ -32,6 +34,14 @@ pub fn subscription() -> iced::Subscription<Event> {
                 )),
                 State::CreatedConnection => Some((
                     result_to_event(
+                        settings_connection().await,
+                        "create settings connection",
+                        Event::SettingsConnection,
+                    ),
+                    State::CreatedSettingsConnection,
+                )),
+                State::CreatedSettingsConnection => Some((
+                    result_to_event(
                         system_connection().await,
                         "create system connection",
                         Event::SystemConnection,
@@ -45,10 +55,18 @@ pub fn subscription() -> iced::Subscription<Event> {
 }
 
 async fn connection() -> zbus::Result<zbus::Connection> {
-    zbus::connection::Builder::session()?
+    let conn = zbus::connection::Builder::session()?
         .name(NAME)?
         .build()
-        .await
+        .await?;
+    conn.object_server();
+    Ok(conn)
+}
+
+// Nameless session connection dedicated to signal-stream consumers, so their
+// backpressure can't wedge the `com.system76.CosmicOsd` name-holding connection.
+async fn settings_connection() -> zbus::Result<zbus::Connection> {
+    zbus::connection::Builder::session()?.build().await
 }
 
 async fn system_connection() -> zbus::Result<zbus::Connection> {

--- a/src/subscriptions/polkit_agent_helper.rs
+++ b/src/subscriptions/polkit_agent_helper.rs
@@ -14,6 +14,26 @@ use tokio::sync::mpsc::{self, Sender};
 const HELPER_BIN_PATH: Option<&str> = option_env!("POLKIT_AGENT_HELPER_1");
 const HELPER_SOCKET_PATH: &str = "/run/polkit/agent-helper.socket";
 
+// polkit-agent-helper-1 lives in different places per distro. Honor the
+// compile-time override, else probe known paths (Fedora/Debian use
+// /usr/lib/polkit-1) so we don't ENOENT on a single hardcoded path.
+const HELPER_BIN_CANDIDATES: &[&str] = &[
+    "/usr/lib/polkit-1/polkit-agent-helper-1",
+    "/usr/libexec/polkit-1/polkit-agent-helper-1",
+    "/usr/libexec/polkit-agent-helper-1",
+];
+
+fn resolve_helper_bin_path() -> &'static str {
+    if let Some(path) = HELPER_BIN_PATH {
+        return path;
+    }
+    HELPER_BIN_CANDIDATES
+        .iter()
+        .copied()
+        .find(|path| Path::new(path).exists())
+        .unwrap_or("/usr/libexec/polkit-agent-helper-1")
+}
+
 #[derive(Clone, Debug)]
 pub enum Event {
     Failed,
@@ -197,7 +217,7 @@ impl AgentHelper {
     async fn new_bin(pw_name: &str) -> io::Result<Self> {
         log::info!("using binary");
 
-        let helper_bin_path = HELPER_BIN_PATH.unwrap_or("/usr/libexec/polkit-agent-helper-1");
+        let helper_bin_path = resolve_helper_bin_path();
         log::trace!("using helper binary from: {helper_bin_path}");
 
         let mut child = Command::new(helper_bin_path)


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

The session-bus connection that owns `com.system76.CosmicOsd` hangs
forever on `org.freedesktop.DBus.Peer.Ping` and
`Introspectable.Introspect`. It goes unresponsive within ~1s of every
cosmic-osd startup, deterministically, while the process stays alive and
idle (no CPU, no panic).

Because the connection owns a well-known name, anything that walks the
session bus blocks on it indefinitely; e.g. `busctl --user tree`, and
`busctl` shell tab-completion (which introspects services).
