### PR TITLE
i18n(is): complete Icelandic translation to 100% parity

### DIFF
--- a/i18n/is/cosmic_osd.ftl
+++ b/i18n/is/cosmic_osd.ftl
@@ -30,3 +30,14 @@ confirm-button =
         [enter-bios] { enter-bios }
        *[other] { confirm }
     }
+
+confirm-title =
+    { $action ->
+        [restart] { restart } núna?
+        [suspend] { suspend } núna?
+        [shutdown] { shutdown } núna?
+        [enter-bios] { enter-bios } núna?
+        [log-out] Loka öllum forritum og skrá út núna?
+        [confirm-device-type] Staðfesta tegund tækis
+        *[other] Framkvæma völdu aðgerðina núna?
+    }


### PR DESCRIPTION
Completes the Icelandic (`is`) localization to 100% key parity with `en`.

Terminology grounded in Íðorðabankinn (the TOLVA computing dictionary, Árnastofnun) and made consistent with COSMIC's existing Icelandic translations. Fluent placeables, selector keys, attributes, and proper nouns are preserved; only human-readable text was translated. Validated with `fluent.syntax` (no Junk) and full en/is key-parity checks.